### PR TITLE
Added explicit dependency on Unidecode

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,6 +16,7 @@
 # If not, see <https://www.gnu.org/licenses/>.
 
 
+Unidecode<1.1,>=0.04
 pytz==2018.9  # https://github.com/stub42/pytz
 python-slugify==2.0.1  # https://github.com/un33k/python-slugify
 Pillow==5.4.1  # https://github.com/python-pillow/Pillow


### PR DESCRIPTION
Without this explicit dependency when one does

 pip3 install -r requirements/local.txt

as required by docs/install.rst, the following error comes up:

 ERROR: django-filer 1.4.4 has requirement Unidecode<1.1,>=0.04, but
        you'll have unidecode 1.1.1 which is incompatible.

That happens because the requirement python-slugify==2.0.1 pulls
Unidecode-version 1.1.1. So adding the explicit requirement before
python-slugify pulls the correct version needed later on by
django-filer.